### PR TITLE
Feature/encoder variants

### DIFF
--- a/trans/__init__.py
+++ b/trans/__init__.py
@@ -6,6 +6,7 @@ LR_SCHEDULER_MAPPING = {}
 def register_component(name, type_):
     """
     This method can be used as a decorator to add components (encoder, optimizer or lr scheduler) to the cli interface.
+
     Args:
         name: name of the component
         type_: type of the component

--- a/trans/__init__.py
+++ b/trans/__init__.py
@@ -1,0 +1,34 @@
+ENCODER_MAPPING = {}
+OPTIMIZER_MAPPING = {}
+LR_SCHEDULER_MAPPING = {}
+
+
+def register_component(name, type_):
+    """
+    This method can be used as a decorator to add components (encoder, optimizer or lr scheduler) to the cli interface.
+    Args:
+        name: name of the component
+        type_: type of the component
+
+    Returns:
+        None
+    """
+    def register_component_cls(cls):
+        if type_ == "encoder":
+            if name not in ENCODER_MAPPING:
+                ENCODER_MAPPING[name] = cls
+        elif type_ == "optimizer":
+            if name not in OPTIMIZER_MAPPING:
+                OPTIMIZER_MAPPING[name] = cls
+        elif type_ == "lr_scheduler":
+            if name not in LR_SCHEDULER_MAPPING:
+                LR_SCHEDULER_MAPPING[name] = cls
+
+        return cls
+
+    return register_component_cls
+
+
+from .optimizers import *
+from .encoders import *
+

--- a/trans/encoders.py
+++ b/trans/encoders.py
@@ -15,6 +15,7 @@ class LSTMEncoder(torch.nn.LSTM):
             hidden_size=dargs['enc_hidden_dim'],
             num_layers=dargs['enc_layers'],
             bidirectional=dargs['enc_bidirectional'],
+            dropout=dargs['enc_dropout'],
             device=dargs['device']
         )
 
@@ -26,6 +27,10 @@ class LSTMEncoder(torch.nn.LSTM):
                             help="Number of encoder LSTM layers.")
         parser.add_argument("--enc-bidirectional", type=bool, default=True,
                             help="If LSTM is bidirectional.")
+        parser.add_argument("--enc-dropout", type=float, default=0.,
+                            help="Dropout probability after each LSTM layer"
+                                 "(except the last layer).")
+
 
     @property
     def output_size(self):
@@ -43,6 +48,7 @@ class TransformerEncoder(torch.nn.Module):
             d_model=dargs['char_dim'],
             nhead=dargs['enc_nhead'],
             dim_feedforward=dargs['enc_dim_feedforward'],
+            dropout=dargs['enc_dropout'],
             device=dargs['device']
         )
         self.transformer_encoder = torch.nn.TransformerEncoder(
@@ -66,6 +72,8 @@ class TransformerEncoder(torch.nn.Module):
                             help="Number of Transformer heads.")
         parser.add_argument("--enc-dim-feedforward", type=int, default=1024,
                             help="Number of Transformer heads.")
+        parser.add_argument("--enc-dropout", type=float, default=0.1,
+                            help="Dropout probability.")
 
 
 class PositionalEncoding(torch.nn.Module):

--- a/trans/encoders.py
+++ b/trans/encoders.py
@@ -9,14 +9,15 @@ import torch
 
 @register_component('lstm', 'encoder')
 class LSTMEncoder(torch.nn.LSTM):
-    def __init__(self, dargs: dict):
+    """LSTM-based encoder."""
+    def __init__(self, args: argparse.Namespace):
         super().__init__(
-            input_size=dargs['char_dim'],
-            hidden_size=dargs['enc_hidden_dim'],
-            num_layers=dargs['enc_layers'],
-            bidirectional=dargs['enc_bidirectional'],
-            dropout=dargs['enc_dropout'],
-            device=dargs['device']
+            input_size=args.char_dim,
+            hidden_size=args.enc_hidden_dim,
+            num_layers=args.enc_layers,
+            bidirectional=args.enc_bidirectional,
+            dropout=args.enc_dropout,
+            device=args.device
         )
 
     @staticmethod
@@ -38,23 +39,24 @@ class LSTMEncoder(torch.nn.LSTM):
 
 @register_component('transformer', 'encoder')
 class TransformerEncoder(torch.nn.Module):
-    def __init__(self, dargs: dict):
+    """Transformber-based encoder."""
+    def __init__(self, args: argparse.Namespace):
         super().__init__()
-        self.d_model = dargs['char_dim']
+        self.d_model = args.char_dim
         self.pos_encoding = PositionalEncoding(
-            d_model=dargs['char_dim'],
-            dropout=dargs['enc_dropout']
+            d_model=args.char_dim,
+            dropout=args.enc_dropout
         )
         self.encoder_layer = torch.nn.TransformerEncoderLayer(
-            d_model=dargs['char_dim'],
-            nhead=dargs['enc_nhead'],
-            dim_feedforward=dargs['enc_dim_feedforward'],
-            dropout=dargs['enc_dropout'],
-            device=dargs['device']
+            d_model=args.char_dim,
+            nhead=args.enc_nhead,
+            dim_feedforward=args.enc_dim_feedforward,
+            dropout=args.enc_dropout,
+            device=args.device
         )
         self.transformer_encoder = torch.nn.TransformerEncoder(
             encoder_layer=self.encoder_layer,
-            num_layers=dargs['enc_layers']
+            num_layers=args.enc_layers
         )
 
     def forward(self, src, mask=None, src_key_padding_mask=None):
@@ -78,6 +80,7 @@ class TransformerEncoder(torch.nn.Module):
 
 
 class PositionalEncoding(torch.nn.Module):
+    """Positional encoding for embeddings used by the Transformer encoder."""
     def __init__(self, d_model: int, dropout: float = 0.1, max_len: int = 150):
         super().__init__()
         self.dropout = torch.nn.Dropout(p=dropout)

--- a/trans/encoders.py
+++ b/trans/encoders.py
@@ -35,7 +35,7 @@ class LSTMEncoder(torch.nn.LSTM):
 class TransformerEncoder(torch.nn.Module):
     def __init__(self, dargs: dict):
         super().__init__()
-        self.output_size = dargs['char_dim']
+        self.d_model = dargs['char_dim']
         self.pos_encoding = PositionalEncoding(
             d_model=dargs['char_dim']
         )
@@ -51,16 +51,20 @@ class TransformerEncoder(torch.nn.Module):
         )
 
     def forward(self, src, mask=None, src_key_padding_mask=None):
-        pos_encoded = self.pos_encoding(src)
-        return self.transformer_encoder(pos_encoded, mask, src_key_padding_mask), 0
+        pos_encoded = self.pos_encoding(src * math.sqrt(self.d_model))
+        return self.transformer_encoder(pos_encoded, mask, src_key_padding_mask), None
+
+    @property
+    def output_size(self):
+        return self.d_model
 
     @staticmethod
     def add_args(parser) -> None:
-        parser.add_argument("--enc-layers", type=int, default=2,
+        parser.add_argument("--enc-layers", type=int, default=4,
                             help="Number of Transformer encoder layers.")
-        parser.add_argument("--enc-nhead", type=int, default=2,
+        parser.add_argument("--enc-nhead", type=int, default=4,
                             help="Number of Transformer heads.")
-        parser.add_argument("--enc-dim-feedforward", type=int, default=100,
+        parser.add_argument("--enc-dim-feedforward", type=int, default=1024,
                             help="Number of Transformer heads.")
 
 

--- a/trans/encoders.py
+++ b/trans/encoders.py
@@ -42,7 +42,8 @@ class TransformerEncoder(torch.nn.Module):
         super().__init__()
         self.d_model = dargs['char_dim']
         self.pos_encoding = PositionalEncoding(
-            d_model=dargs['char_dim']
+            d_model=dargs['char_dim'],
+            dropout=dargs['enc_dropout']
         )
         self.encoder_layers = torch.nn.TransformerEncoderLayer(
             d_model=dargs['char_dim'],

--- a/trans/encoders.py
+++ b/trans/encoders.py
@@ -1,0 +1,91 @@
+"""Encoder classes used by the Transducer model."""
+
+from typing import Any, Dict, List, Optional, TextIO, Union
+import abc
+import math
+
+
+import torch
+
+
+class LSTMEncoder(torch.nn.LSTM):
+    def __init__(self, dargs: dict):
+        super().__init__(
+            input_size=dargs['char_dim'],
+            hidden_size=dargs['enc_hidden_dim'],
+            num_layers=dargs['enc_layers'],
+            bidirectional=dargs['enc_bidirectional'],
+            device=dargs['device']
+        )
+
+    @staticmethod
+    def add_args(parser) -> None:
+        parser.add_argument("--enc-hidden-dim", type=int, default=200,
+                            help="Encoder LSTM state dimension.")
+        parser.add_argument("--enc-layers", type=int, default=1,
+                            help="Number of encoder LSTM layers.")
+        parser.add_argument("--enc-bidirectional", type=bool, default=True,
+                            help="If LSTM is bidirectional.")
+
+    @property
+    def output_size(self):
+        return self.hidden_size * 2 if self.bidirectional else self.hidden_size
+
+
+class TransformerEncoder(torch.nn.Module):
+    def __init__(self, dargs: dict):
+        super().__init__()
+        self.output_size = dargs['char_dim']
+        self.pos_encoding = PositionalEncoding(
+            d_model=dargs['char_dim']
+        )
+        self.encoder_layers = torch.nn.TransformerEncoderLayer(
+            d_model=dargs['char_dim'],
+            nhead=dargs['enc_nhead'],
+            dim_feedforward=dargs['enc_dim_feedforward'],
+            device=dargs['device']
+        )
+        self.transformer_encoder = torch.nn.TransformerEncoder(
+            encoder_layer=self.encoder_layers,
+            num_layers=dargs['enc_layers']
+        )
+
+    def forward(self, src, mask=None, src_key_padding_mask=None):
+        pos_encoded = self.pos_encoding(src)
+        return self.transformer_encoder(pos_encoded, mask, src_key_padding_mask), 0
+
+    @staticmethod
+    def add_args(parser) -> None:
+        parser.add_argument("--enc-layers", type=int, default=2,
+                            help="Number of Transformer encoder layers.")
+        parser.add_argument("--enc-nhead", type=int, default=2,
+                            help="Number of Transformer heads.")
+        parser.add_argument("--enc-dim-feedforward", type=int, default=100,
+                            help="Number of Transformer heads.")
+
+
+class PositionalEncoding(torch.nn.Module):
+    def __init__(self, d_model: int, dropout: float = 0.1, max_len: int = 150):
+        super().__init__()
+        self.dropout = torch.nn.Dropout(p=dropout)
+
+        position = torch.arange(max_len).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, d_model, 2) * (-math.log(10000.0) / d_model))
+        pe = torch.zeros(max_len, 1, d_model)
+        pe[:, 0, 0::2] = torch.sin(position * div_term)
+        pe[:, 0, 1::2] = torch.cos(position * div_term)
+        self.register_buffer('pe', pe)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: Tensor, shape [seq_len, batch_size, embedding_dim]
+        """
+        x = x + self.pe[:x.size(0)]
+        return self.dropout(x)
+
+
+ENCODER_MAPPING = {
+    'lstm': LSTMEncoder,
+    'transformer': TransformerEncoder,
+}

--- a/trans/optimizers.py
+++ b/trans/optimizers.py
@@ -1,0 +1,76 @@
+"""Optimizer classes and lr scheduler used in training."""
+
+import argparse
+from trans import register_component
+
+import torch
+
+
+@register_component('adam', 'optimizer')
+class Adam(torch.optim.Adam):
+    def __init__(self, params, dargs: dict):
+        super().__init__(
+            params,
+            lr=dargs['lr'],
+            betas=dargs['betas'],
+            eps=dargs['eps'],
+            weight_decay=dargs['weight_decay'],
+            amsgrad=dargs['amsgrad']
+        )
+
+    @staticmethod
+    def add_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--lr", type=float, default=0.001)
+        parser.add_argument("--betas", type=tuple, default=(0.9, 0.999))
+        parser.add_argument("--eps", type=float, default=1e-08)
+        parser.add_argument("--weight-decay", type=float, default=0)
+        parser.add_argument("--amsgrad", type=bool, default=False)
+
+
+@register_component('adadelta', 'optimizer')
+class Adadelta(torch.optim.Adadelta):
+    def __init__(self, params, dargs: dict):
+        super().__init__(
+            params,
+            lr=dargs['lr'],
+            rho=dargs['rho'],
+            eps=dargs['eps'],
+            weight_decay=dargs['weight_decay']
+        )
+
+    @staticmethod
+    def add_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--lr", type=float, default=1.0)
+        parser.add_argument("--rho", type=float, default=0.9)
+        parser.add_argument("--eps", type=float, default=1e-06)
+        parser.add_argument("--weight-decay", type=float, default=0.)
+
+
+@register_component('inv_sr', 'lr_scheduler')
+class InvSRScheduler(torch.optim.lr_scheduler._LRScheduler):
+    def __init__(self, optimizer: torch.optim, dargs: dict):
+        self.warmup_steps = dargs['warmup_steps']
+        lr = optimizer.param_groups[0]['lr']
+        self.init_lr = dargs['warmup_init_lr'] if dargs['warmup_steps'] > 0 else lr
+        self.final_lr = lr
+        super().__init__(
+            optimizer,
+            last_epoch=dargs['last_epoch'],
+            verbose=dargs['verbose']
+        )
+
+    def get_lr(self):
+        if self.last_epoch == 0:
+            return [self.init_lr for group in self.optimizer.param_groups]
+        if self.last_epoch < self.warmup_steps:
+            lr = self.init_lr + ((self.final_lr - self.init_lr) / self.warmup_steps) * self.last_epoch
+        else:
+            lr = self.final_lr * (self.warmup_steps ** 0.5 if self.warmup_steps > 0 else 1) * self.last_epoch**-0.5
+        return [lr for group in self.optimizer.param_groups]
+
+    @staticmethod
+    def add_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--warmup-init-lr", type=float, default=0.00001)
+        parser.add_argument("--warmup-steps", type=int, default=20)
+        parser.add_argument("--last-epoch", type=int, default=-1)
+        parser.add_argument("--verbose", type=bool, default=False)

--- a/trans/optimizers.py
+++ b/trans/optimizers.py
@@ -8,14 +8,15 @@ import torch
 
 @register_component('adam', 'optimizer')
 class Adam(torch.optim.Adam):
-    def __init__(self, params, dargs: dict):
+    """Adam optimizer."""
+    def __init__(self, params, args: argparse.Namespace):
         super().__init__(
             params,
-            lr=dargs['lr'],
-            betas=dargs['betas'],
-            eps=dargs['eps'],
-            weight_decay=dargs['weight_decay'],
-            amsgrad=dargs['amsgrad']
+            lr=args.lr,
+            betas=args.betas,
+            eps=args.eps,
+            weight_decay=args.weight_decay,
+            amsgrad=args.amsgrad
         )
 
     @staticmethod
@@ -29,13 +30,14 @@ class Adam(torch.optim.Adam):
 
 @register_component('adadelta', 'optimizer')
 class Adadelta(torch.optim.Adadelta):
-    def __init__(self, params, dargs: dict):
+    """Adadelta optimizer."""
+    def __init__(self, params, args: argparse.Namespace):
         super().__init__(
             params,
-            lr=dargs['lr'],
-            rho=dargs['rho'],
-            eps=dargs['eps'],
-            weight_decay=dargs['weight_decay']
+            lr=args.lr,
+            rho=args.rho,
+            eps=args.eps,
+            weight_decay=args.weight_decay
         )
 
     @staticmethod
@@ -48,15 +50,16 @@ class Adadelta(torch.optim.Adadelta):
 
 @register_component('inv_sr', 'lr_scheduler')
 class InvSRScheduler(torch.optim.lr_scheduler._LRScheduler):
-    def __init__(self, optimizer: torch.optim, dargs: dict):
-        self.warmup_steps = dargs['warmup_steps']
+    """Inverse square root scheduler."""
+    def __init__(self, optimizer: torch.optim, args: argparse.Namespace):
+        self.warmup_steps = args.warmup_steps
         lr = optimizer.param_groups[0]['lr']
-        self.init_lr = dargs['warmup_init_lr'] if dargs['warmup_steps'] > 0 else lr
+        self.init_lr = args.warmup_init_lr if args.warmup_steps > 0 else lr
         self.final_lr = lr
         super().__init__(
             optimizer,
-            last_epoch=dargs['last_epoch'],
-            verbose=dargs['verbose']
+            last_epoch=args.last_epoch,
+            verbose=args.verbose
         )
 
     def get_lr(self):

--- a/trans/test_transducer.py
+++ b/trans/test_transducer.py
@@ -1,5 +1,6 @@
 """Unit tests for transducer.py."""
 import unittest
+import argparse
 
 import numpy as np
 from scipy.special import log_softmax
@@ -24,8 +25,21 @@ class TransducerTests(unittest.TestCase):
         vocabulary_.encode_input("foo")
         vocabulary_.encode_actions("bar")
         expert = optimal_expert.OptimalExpert()
+
+        args = argparse.Namespace(
+            device='cpu',
+            char_dim=100,
+            action_dim=100,
+            enc_type='lstm',
+            enc_hidden_dim=200,
+            enc_layers=1,
+            enc_bidirectional=True,
+            enc_dropout=0.,
+            dec_hidden_dim=100,
+            dec_layers=1
+        )
         cls.transducer = transducer.Transducer(
-            vocabulary_, expert, 3, 3, 3, 1, 3, 1)
+            vocabulary_, expert, args)
 
     def test_sample(self):
         log_probs = log_softmax([5, 4, 10, 1])

--- a/trans/train.py
+++ b/trans/train.py
@@ -287,7 +287,7 @@ if __name__ == "__main__":
                         help="Maximal patience for early stopping.")
     parser.add_argument("--epochs", type=int, default=60,
                         help="Maximal number of training epochs.")
-    parser.add_argument("--batch-size", type=str, default=5,
+    parser.add_argument("--batch-size", type=int, default=5,
                         help="Batch size.")
     parser.add_argument("--sed-em-iterations", type=int, default=10,
                         help="SED EM iterations.")

--- a/trans/transducer.py
+++ b/trans/transducer.py
@@ -12,7 +12,7 @@ from trans import vocabulary
 from trans.actions import ConditionalCopy, ConditionalDel, ConditionalIns, \
     ConditionalSub, Edit, EndOfSequence, GenerativeEdit, BeginOfSequence
 from trans.vocabulary import BEGIN_WORD, COPY, DELETE, END_WORD
-from trans import encoders
+from trans import ENCODER_MAPPING
 
 
 MAX_ACTION_SEQ_LEN = 150
@@ -78,7 +78,7 @@ class Transducer(torch.nn.Module):
             embedding_dim=dargs['char_dim'],
             device=self.device,
         )
-        self.enc = encoders.ENCODER_MAPPING[dargs['enc_type']](dargs)
+        self.enc = ENCODER_MAPPING[dargs['enc_type']](dargs)
 
         # decoder
         self.act_lookup = torch.nn.Embedding(

--- a/trans/transducer.py
+++ b/trans/transducer.py
@@ -12,6 +12,7 @@ from trans import vocabulary
 from trans.actions import ConditionalCopy, ConditionalDel, ConditionalIns, \
     ConditionalSub, Edit, EndOfSequence, GenerativeEdit, BeginOfSequence
 from trans.vocabulary import BEGIN_WORD, COPY, DELETE, END_WORD
+from trans import encoders
 
 
 MAX_ACTION_SEQ_LEN = 150
@@ -58,12 +59,10 @@ class Expansion:
 
 class Transducer(torch.nn.Module):
     def __init__(self, vocab: vocabulary.Vocabularies,
-                 expert: optimal_expert.Expert, char_dim: int, action_dim: int,
-                 enc_hidden_dim: int, enc_layers: int, dec_hidden_dim: int,
-                 dec_layers: int, device: str = 'cpu', **kwargs):
+                 expert: optimal_expert.Expert, dargs: dict):
 
         super().__init__()
-        self.device = torch.device(device)
+        self.device = torch.device(dargs['device'])
 
         self.vocab = vocab
         self.optimal_expert = expert
@@ -76,42 +75,35 @@ class Transducer(torch.nn.Module):
         # encoder
         self.char_lookup = torch.nn.Embedding(
             num_embeddings=self.number_characters,
-            embedding_dim=char_dim,
+            embedding_dim=dargs['char_dim'],
             device=self.device,
         )
-
-        self.enc = torch.nn.LSTM(
-            input_size=char_dim,
-            hidden_size=enc_hidden_dim,
-            num_layers=enc_layers,
-            bidirectional=True,
-            device=self.device,
-        )
+        self.enc = encoders.ENCODER_MAPPING[dargs['enc_type']](dargs)
 
         # decoder
         self.act_lookup = torch.nn.Embedding(
             num_embeddings=self.number_actions,
-            embedding_dim=action_dim,
+            embedding_dim=dargs['action_dim'],
             device=self.device,
         )
 
-        decoder_input_dim = enc_hidden_dim * 2 + action_dim
+        decoder_input_dim = self.enc.output_size + dargs['action_dim']
 
         self.dec = torch.nn.LSTM(
             input_size=decoder_input_dim,
-            hidden_size=dec_hidden_dim,
-            num_layers=dec_layers,
+            hidden_size=dargs['dec_hidden_dim'],
+            num_layers=dargs['dec_layers'],
             device=self.device,
         )
 
         self.h0_c0 = (  # batch size 1
-            torch.zeros((dec_layers, 1, dec_hidden_dim), device=self.device),
-            torch.zeros((dec_layers, 1, dec_hidden_dim), device=self.device),
+            torch.zeros((dargs['dec_layers'], 1, dargs['dec_hidden_dim']), device=self.device),
+            torch.zeros((dargs['dec_layers'], 1, dargs['dec_hidden_dim']), device=self.device),
         )
 
         # classifier
         self.W = torch.nn.Linear(
-            in_features=dec_hidden_dim,
+            in_features=dargs['dec_hidden_dim'],
             out_features=self.number_actions,
             device=self.device,
 


### PR DESCRIPTION
This PR allows to use different encoders for the neural transducer (LSTM, Transformer).

Major changes in this PR:
- A Transformer-based encoder can now be used.
- Adam can be used as a optimiser (so far only Adadelta).
- The possibility to use an Inverse Square Root Scheduler is added.
- The register_method method has been added. This method allows to easily register encoders, optimisers and schedulers such that the corresponding class can be easily instantiated from the corresponding cli option value.
- Generally, this PR adds user flexibility as more parameters for encoder and optimiser (and scheduler) can be passed via cli.

**Important**: This PR should not be merged into development before performing this PR #1. The reason is simple: It will create less complications. 